### PR TITLE
Semantic editor displays treeview objects

### DIFF
--- a/src/DataStructures/Graph.js
+++ b/src/DataStructures/Graph.js
@@ -4,6 +4,7 @@
 
 import { CollectionsBookmarkOutlined, ContactSupportOutlined } from "@material-ui/icons";
 import { currentObjects, getModelName, createVertex } from "../UIElements/CanvasDraw";
+import {SemanticIdentity} from "./SemanticIdentity";
 
 
 
@@ -506,13 +507,24 @@ export class Graph {
 
     addVertex(vertex) {
         if (this.getVertexNode(vertex) === null) { // if its the original vertex
+            vertex.originalUUID = vertex.semanticIdentity.UUID; 
             vertex = new VertexNode(vertex);
             this.rootVertices.add(vertex);
         } else { // else its a copy of the original
             console.log("a copy vertex was attempted")
+            
             let newTitle = ":: " + vertex.title
             vertex.title = newTitle
+            vertex.originalVertex = false;
+            /* For now im going to give the copies their own unique semantic UUID, as a lot of stuff in the program hinges off of vertex items
+            having their own unique sID. as a work around i've created a value in the vertex object to store the sID of the original vertex so that
+            any functions that require the original UUID of the original vertex can still be used. - cooper*/
+            vertex.originalUUID = vertex.semanticIdentity.UUID; 
+            let sID = new SemanticIdentity(vertex.title,"","","", undefined ,[]) 
+            vertex.semanticIdentity = sID;
             vertex = new VertexNode(vertex);
+
+           
             this.rootVertices.add(vertex);
             console.log(vertex)
         }

--- a/src/DataStructures/Vertex.js
+++ b/src/DataStructures/Vertex.js
@@ -4,7 +4,7 @@
 
 import { drawMarker, distanceThreshold, getCurrentRenderKey, getCurrentModel } from "../UIElements/CanvasDraw";
 import { getModelRenderKey } from "../UIElements/ContainmentTree";
-import { SemanticIdentity } from "./SemanticIdentity";
+import { SemanticIdentity, createUUID } from "./SemanticIdentity";
 
 export var padding = 5;
 export var defaultColour = "#FFD5A9";
@@ -30,6 +30,8 @@ export class Vertex {
         this.selected = false;
         this.imageElements = {};
         this.fontSize = 12;
+        this.orignalVertex = true; // bool to see if the selected vertex is the original
+        this.originalUUID = this.originalUUID // going to store the UUID of the original vertex here as canvas objects need to be given a unique semanticUUID 
         this.isContainer = false; //Ignore this now, Kieth explained how containers work after finishing old implementation, direction other team was going was wrong - Lachlan
 
         // Note these values often change in runtime

--- a/src/UIElements/CanvasDraw.js
+++ b/src/UIElements/CanvasDraw.js
@@ -1828,14 +1828,14 @@ export function createVertex(x1, y1, width, height,name,content,colour,icons,ima
 }
 
 export function updateVertex(selectedObject){ // function to update the data of the contaimnment tree object and all other objects sharing the semantic- cooper
-    let vertex = getLinkedVertex(selectedObject);
+    let vertex = getLinkedVertex(selectedObject); // 'vertex' refers to the treeview object.
     vertex.text = selectedObject.title + " 🟧";
     vertex.colour = selectedObject.colour;
     vertex.content = selectedObject.content;
     vertex.width = selectedObject.width;
     vertex.height = selectedObject.height;
     for(let verticies of currentObjects.flatten()){
-        if(vertex.semanticIdentity.UUID === verticies.semanticIdentity.UUID && verticies !== selectedObject){ 
+        if(vertex.semanticIdentity.UUID === verticies.originalUUID && verticies !== selectedObject){ // updates all of the canvas objects that come from the treeview object.
             verticies.title = vertex.text.replace(" 🟧", "")
             verticies.title = ":: " + verticies.title 
             verticies.colour = vertex.colour;
@@ -1846,7 +1846,7 @@ export function updateVertex(selectedObject){ // function to update the data of 
 
 export function getLinkedVertex(selectedObject){ // grabs the contaiment tree object - cooper
     for(let vertex of vertexData){
-        if(vertex.semanticIdentity.UUID === selectedObject.semanticIdentity.UUID)
+        if(vertex.semanticIdentity.UUID === selectedObject.originalUUID)
         return vertex;
     }
 }

--- a/src/UIElements/ContainmentTree.js
+++ b/src/UIElements/ContainmentTree.js
@@ -242,6 +242,8 @@ export function handleAddVertex(vertexName, parentKey = 0){
         data: NaN,
         state: {opened: true},
         type: "treeVertex",
+        typeName: "Vertex",
+        originalVertex: true,
         renderKey: getTotalRenderKeys(),
         parentRenderKey: parentKey,
         content: "",
@@ -262,6 +264,8 @@ export function handleAddVertex(vertexName, parentKey = 0){
         data: decoyVertexData[vertexData.length],
         state: {opened: true},
         type: "treeVertex",
+        typeName: "Vertex",
+        originalVertex: true,
         renderKey: getTotalRenderKeys(),
         parentRenderKey: parentKey,
         content: "",
@@ -332,7 +336,7 @@ export function handleAddModel(modelName, rKey=getSelectedFolderKey(), semanticI
 
 export function handleDeleteVertex(selectedUUID){
     for(let vertex of currentObjects.flatten()){
-        if(vertex.semanticIdentity.UUID === selectedUUID){
+        if(vertex.originalUUID === selectedUUID){
             currentObjects.remove(vertex)
         }
     }

--- a/src/UIElements/LeftMenu.js
+++ b/src/UIElements/LeftMenu.js
@@ -149,7 +149,6 @@ export class LeftMenu extends React.Component{
             console.log(this.state.selectedObject);
             if(this.state.selectedObject.typeName === "Vertex"){
                 vertexDeleteElement(this.state.selectedObject);
-                handleDeleteVertex(this.state.selectedObject.semanticIdentity.UUID)
             }
             else{
                 deleteElement(this.state.selectedObject);

--- a/src/UIElements/SemanticDomainEditor.js
+++ b/src/UIElements/SemanticDomainEditor.js
@@ -40,6 +40,7 @@ import {
 
 // In program imports
 import {currentObjects} from "./CanvasDraw";
+import {vertexData} from "./ContainmentTree"
 
 // Globals
 let rows;
@@ -314,9 +315,10 @@ export function resetRows() {
     let newRows = [];
     let currentObjectsFlattened = currentObjects.flatten();
 
-    for (let i = 0; i < currentObjectsFlattened.length; i++) {
-        newRows.push(getRowForObject(currentObjectsFlattened[i]));
-
+    for (let i = 0; i < vertexData.length; i++) {
+        newRows.push(getRowForObject(vertexData[i]));
+    }
+    for(let i = 0; i < currentObjectsFlattened.length; i++){
         // Add Arrow Ends
         if (currentObjectsFlattened[i].typeName === "Arrow") {
             newRows.push(getRowForObject(currentObjectsFlattened[i].sourceEdgeEnd));


### PR DESCRIPTION
Semantic editor now displays treeview stuff rather than the canvas stuff. also updated the canvas items so that they all have unique UUID's and store their original UUID within themselves for use in functions. this was bec ause a lot of the functionality in this program hinges off of the fact that the canvas objects need to have unique identifiers and a lot of functions used the semantic UUID