### PR TITLE
Renabled category selector.

### DIFF
--- a/src/DataStructures/Vertex.js
+++ b/src/DataStructures/Vertex.js
@@ -481,7 +481,7 @@ export class Vertex {
 
         }
 
-       /* for (let i = 0; i < this.icons[0].length; i++) {
+        for (let i = 0; i < this.icons[0].length; i++) {
 
             if (this.icons[1][i] === true) {
                 if (this.icons[2][i] === true) {
@@ -508,7 +508,7 @@ export class Vertex {
                 yPos += iconHeight + (iconPadding * 2);
             }
             
-        } */
+        } 
 
         // Reset color for text
         canvasContext.fillStyle = "#000000";

--- a/src/UIElements/LeftMenu.js
+++ b/src/UIElements/LeftMenu.js
@@ -92,7 +92,7 @@ export class LeftMenu extends React.Component{
             this.formRef = element;
         };
 
-        //this.setIcons();
+        this.setIcons();
 
     }
     handleChange(event){


### PR DESCRIPTION
-Currently set to localhost:8080 for server address
- Will not work on gh pages as gh pages can only host static websites. (can't use the express server api)
-this could be made static, however it means you would need to update code
 whenever an icon is added/deleted from the S23M icons folder