### PR TITLE
changed how some objects are copied

### DIFF
--- a/src/Serialisation/NewFileManager.js
+++ b/src/Serialisation/NewFileManager.js
@@ -13,19 +13,20 @@ import { getDecoyFolderData, getDecoyModelData, getDecoyVertexData, getFolderDat
 import { CompassCalibrationOutlined } from "@material-ui/icons";
 
 //Get all the data that needs to be saved, to restore a session
-// .slice() is added to everything returning arrays as we just want the value, not a reference.
+// .slice() only creates a shallow copy of arrays which means that it copies literal values but only makes referneces to arrays and objects.
+// turning the object into a string and back into an object creates a deep copy which is an actual standalone copy and not an array of references
 export function getSaveData() {
     let vertexObjects = currentObjects.flatten(true, false);
     let arrowObjects = currentObjects.flatten(false, true);
-    let treeData = getTreeData().slice();
-    let folderData = getFolderData().slice();
-    let decoyFolderData = getDecoyFolderData().slice();
+    let treeData = JSON.parse(JSON.stringify(getTreeData()))
+    let folderData = JSON.parse(JSON.stringify(getFolderData()))
+    let decoyFolderData = JSON.parse(JSON.stringify(getDecoyFolderData()))
 
-    let vertexData = getVertexData().slice();
-    let decoyVertexData = getDecoyVertexData().slice();
+    let vertexData = JSON.parse(JSON.stringify(getVertexData()));
+    let decoyVertexData = JSON.parse(JSON.stringify(getDecoyVertexData()));
 
-    let modelObjects = getModelData().slice();
-    let decoyModelObjects = getDecoyModelData().slice();
+    let modelObjects = JSON.parse(JSON.stringify(getModelData()));
+    let decoyModelObjects = JSON.parse(JSON.stringify(getDecoyModelData())) 
 
     let totalRenderKeys = getTotalRenderKeys();
     let totalModels = getTotalModels();

--- a/src/UIElements/CanvasDraw.js
+++ b/src/UIElements/CanvasDraw.js
@@ -10,6 +10,7 @@ import {getFolderNameFromKey, getModelData,getModelNameFromKey,handleAddModel, h
 import { rgbToHex } from "@material-ui/core";
 import { Canvas } from "./Canvas";
 import { setCurrentGraph } from "./MainView";
+import { createSaveState } from "../Serialisation/NewFileManager";
 
 //false unless the onMouseMove function is executing, Is used to stop vertex created with leftmenu tool creating multiple vertex's when dragging for an inital size
 let dragging = false;
@@ -1482,6 +1483,7 @@ export function onLeftMouseRelease(canvas, x, y) {
 
         canvas.props.setLeftMenu(newObject);
         canvas.props.setMode(Tool.Select);
+        createSaveState();
     }
     if (canvas.tool === Tool.Artifact) {
         let newObject = createArtifact(canvas, mouseStartX, mouseStartY);

--- a/src/UIElements/ContainmentTree.js
+++ b/src/UIElements/ContainmentTree.js
@@ -462,6 +462,7 @@ export function handleModelRebase(mKey,newRkey){
     }
     console.log(modelObjects)
     treeNeedsUpdate = 1;
+    createSaveState();
 }
 
 


### PR DESCRIPTION
.slice() only creates shallow copies of objects, so it only creates references for objects and arrays